### PR TITLE
Fix: add wp_localize_script to provide tmwSlot url to frontend

### DIFF
--- a/tmw-slot-machine.php
+++ b/tmw-slot-machine.php
@@ -49,6 +49,11 @@ function tmw_slot_machine_enqueue_assets() {
         tmw_slot_machine_asset_version('assets/js/slot-machine.js'),
         true
     );
+
+    // Provide JS access to the plugin URL for image paths
+    wp_localize_script('tmw-slot-js', 'tmwSlot', [
+        'url' => TMW_SLOT_MACHINE_URL,
+    ]);
 }
 
 // Register shortcode


### PR DESCRIPTION
## Summary
- localize the tmw-slot-js script to expose the plugin URL for frontend asset loading

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e664c8413c8324bd3a3a254a4db3e8