### PR TITLE
Fix: enable reel icon randomization on SPIN NOW click

### DIFF
--- a/assets/js/slot-machine.js
+++ b/assets/js/slot-machine.js
@@ -149,3 +149,17 @@ document.addEventListener('DOMContentLoaded', () => {
     r.style.backgroundPosition = 'center';
   });
 });
+
+// === TMW Enhancement: Re-spin on button click ===
+document.addEventListener('DOMContentLoaded', () => {
+  const spinBtn = document.querySelector('.tmw-spin-btn');
+  const reels = document.querySelectorAll('.reel');
+  if (!spinBtn || !reels.length) return;
+
+  spinBtn.addEventListener('click', () => {
+    reels.forEach(r => {
+      const rand = Math.floor(Math.random() * tmwIcons.length);
+      r.style.backgroundImage = `url(${tmwSlot.url}assets/img/${tmwIcons[rand]})`;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a DOMContentLoaded handler that re-randomizes reel icons whenever the SPIN NOW button is pressed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e666a3aabc8324aa6cba7362f96b54