### PR TITLE
Adjust bounce animation timing

### DIFF
--- a/assets/css/slot-machine.css
+++ b/assets/css/slot-machine.css
@@ -25,6 +25,10 @@
   margin: 20px 0;
 }
 
+.tmw-reels.bounce {
+  animation: bounce 0.33s ease-in-out 0s 6;
+}
+
 .reel {
   width: 60px;
   height: 60px;
@@ -45,6 +49,22 @@
   }
   100% {
     transform: translateY(-100%);
+  }
+}
+
+@keyframes bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  25% {
+    transform: translateY(-8px);
+  }
+  50% {
+    transform: translateY(0);
+  }
+  75% {
+    transform: translateY(-4px);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a bounce animation definition for the reel container
- repeat the bounce animation in six short loops so logo flashes occur during the bounce

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e674fabdb083248ba33044792303a1