### PR TITLE
Disable bounce animation and flash results

### DIFF
--- a/assets/css/slot-machine.css
+++ b/assets/css/slot-machine.css
@@ -25,10 +25,6 @@
   margin: 20px 0;
 }
 
-.tmw-reels.bounce {
-  animation: bounce 0.33s ease-in-out 0s 6;
-}
-
 .reel {
   width: 60px;
   height: 60px;
@@ -49,22 +45,6 @@
   }
   100% {
     transform: translateY(-100%);
-  }
-}
-
-@keyframes bounce {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  25% {
-    transform: translateY(-8px);
-  }
-  50% {
-    transform: translateY(0);
-  }
-  75% {
-    transform: translateY(-4px);
   }
 }
 

--- a/assets/js/slot-machine.js
+++ b/assets/js/slot-machine.js
@@ -94,12 +94,12 @@ document.addEventListener('DOMContentLoaded', function() {
     const reelList = Array.from(reels);
     setRandomIconsOnReels(reelList);
 
-    let flashTimeout = null;
+    let flashIntervalId = null;
 
     const stopResultFlash = () => {
-      if (flashTimeout) {
-        clearTimeout(flashTimeout);
-        flashTimeout = null;
+      if (flashIntervalId) {
+        clearInterval(flashIntervalId);
+        flashIntervalId = null;
       }
     };
 
@@ -123,22 +123,18 @@ document.addEventListener('DOMContentLoaded', function() {
       const flashes = Math.floor(Math.random() * 4) + 6; // 6–9 flashes
       let count = 0;
 
-      const runFlash = () => {
+      flashIntervalId = setInterval(() => {
         count += 1;
         reelList.forEach(reel => {
           const icon = iconPool[Math.floor(Math.random() * iconPool.length)];
           setIconOnReel(reel, icon);
         });
 
-        if (count < flashes) {
-          const delay = 200 + Math.floor(Math.random() * 101); // 200–300 ms
-          flashTimeout = setTimeout(runFlash, delay);
-        } else {
-          flashTimeout = null;
+        if (count >= flashes) {
+          clearInterval(flashIntervalId);
+          flashIntervalId = null;
         }
-      };
-
-      runFlash();
+      }, 250);
     };
 
     btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- replace the bounce end animation with a controlled flashing sequence that swaps random icons 6–9 times
- remove the bounce CSS class and keyframes so reels remain stationary after spins

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6780b30208324a46ea867c79d82ab