### PR TITLE
Disable reel transform transition

### DIFF
--- a/assets/css/slot-machine.css
+++ b/assets/css/slot-machine.css
@@ -31,7 +31,7 @@
   background: #222;
   border-radius: 10px;
   box-shadow: inset 0 0 5px rgba(255, 255, 255, 0.15);
-  transition: transform 0.3s;
+  transition: none;
   border: 2px solid rgba(255, 255, 255, 0.05);
 }
 


### PR DESCRIPTION
## Summary
- remove the lingering transform transition from reels so they snap to a stop

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e67b32199883248fe0cccae851dfb2