### PR TITLE
Disable transform transition on reels

### DIFF
--- a/assets/css/slot-machine.css
+++ b/assets/css/slot-machine.css
@@ -31,7 +31,7 @@
   background: #222;
   border-radius: 10px;
   box-shadow: inset 0 0 5px rgba(255, 255, 255, 0.15);
-  transition: none;
+  transition: box-shadow 0.3s, opacity 0.3s;
   border: 2px solid rgba(255, 255, 255, 0.05);
 }
 


### PR DESCRIPTION
## Summary
- prevent reel elements from animating their transform once the spin animation stops by limiting their transition to box-shadow and opacity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e67e069f8c8324ac10a1ffa100b7d7