### PR TITLE
Disable reel transition bounce

### DIFF
--- a/assets/css/slot-machine.css
+++ b/assets/css/slot-machine.css
@@ -31,7 +31,8 @@
   background: #222;
   border-radius: 10px;
   box-shadow: inset 0 0 5px rgba(255, 255, 255, 0.15);
-  transition: box-shadow 0.3s, opacity 0.3s;
+  transition: none !important;
+  transform: none !important;
   border: 2px solid rgba(255, 255, 255, 0.05);
 }
 
@@ -96,4 +97,9 @@
   .tmw-slot-machine {
     width: auto;
   }
+}
+
+.reel {
+  transition: none !important;
+  transform: none !important;
 }


### PR DESCRIPTION
## Summary
- disable all transform transitions on the reel elements to prevent the bounce effect
- reinforce the transition override at the bottom of the stylesheet to avoid cascade conflicts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6804a002c8324b6917920642618f1